### PR TITLE
Add Bluewin config to well known services

### DIFF
--- a/lib/well-known/services.json
+++ b/lib/well-known/services.json
@@ -11,6 +11,12 @@
         "host": "smtp.aol.com",
         "port": 587
     },
+    
+    "Bluewin": {
+        "host": "smtpauths.bluewin.ch",
+        "domains": ["bluewin.ch"],
+        "port": 465
+    },
 
     "DebugMail": {
         "host": "debugmail.io",


### PR DESCRIPTION
Bluewin is a well known email service from Swisscom (https://www.swisscom.ch/en/residential.html) used in Switzerland.